### PR TITLE
Use Entry trait

### DIFF
--- a/src/dedup.rs
+++ b/src/dedup.rs
@@ -1,44 +1,10 @@
-use std::cmp::Ordering;
 use std::collections::HashMap;
-use std::path::Path;
+use entry::Entry;
 use file::FileHash;
-use walkdir::DirEntry;
 
-#[derive(Debug)]
-pub struct SortableDirEntry(DirEntry);
-
-impl SortableDirEntry {
-    pub fn new(entry: DirEntry) -> SortableDirEntry {
-        SortableDirEntry(entry)
-    }
-    
-    pub fn path(&self) -> &Path {
-        self.0.path()
-    }
-}
-
-impl PartialEq for SortableDirEntry {
-    fn eq(&self, other: &Self) -> bool {
-        self.path().eq(other.path())
-    }
-}
-
-impl Eq for SortableDirEntry { }
-
-impl PartialOrd for SortableDirEntry {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        self.path().partial_cmp(other.path())
-    }
-}
-
-impl Ord for SortableDirEntry {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.path().cmp(other.path())
-    }
-}
-
-pub fn group_by_size<I>(paths: I) -> Vec<Vec<SortableDirEntry>>
-    where I: Iterator<Item = (u64, SortableDirEntry)>
+pub fn group_by_size<E, I>(paths: I) -> Vec<Vec<E>>
+    where E: Entry,
+          I: Iterator<Item = (u64, E)>
 {
     let groups = paths.fold(HashMap::new(), |mut map, (len, entry)| {
         map.entry(len).or_insert_with(Vec::new).push(entry);
@@ -51,8 +17,9 @@ pub fn group_by_size<I>(paths: I) -> Vec<Vec<SortableDirEntry>>
         .collect()
 }
 
-pub fn group_by_hash<I>(paths: I, verbose: bool) -> Vec<(Vec<u8>, Vec<SortableDirEntry>)>
-    where I: Iterator<Item = SortableDirEntry>
+pub fn group_by_hash<E, I>(paths: I, verbose: bool) -> Vec<(Vec<u8>, Vec<E>)>
+    where E: Entry + Ord,
+          I: Iterator<Item = E>
 {
     let groups = paths.filter_map(|entry| {
             if verbose {

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,0 +1,57 @@
+use std::cmp::Ordering;
+use std::io::Result;
+use std::path::Path;
+use walkdir::DirEntry;
+
+pub trait Entry {
+    fn path(&self) -> &Path;
+    
+    fn length(&self) -> Result<u64> {
+        self.path().metadata().map(|meta| meta.len())
+    }
+}
+
+impl Entry for DirEntry {
+    fn path(&self) -> &Path {
+        self.path()
+    }
+}
+
+#[derive(Debug)]
+pub struct SortableDirEntry(DirEntry);
+
+impl SortableDirEntry {
+    pub fn new(entry: DirEntry) -> SortableDirEntry {
+        SortableDirEntry(entry)
+    }
+    
+    pub fn path(&self) -> &Path {
+        self.0.path()
+    }
+}
+
+impl Entry for SortableDirEntry {
+    fn path(&self) -> &Path {
+        self.path()
+    }
+}
+
+impl PartialEq for SortableDirEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.path().eq(other.path())
+    }
+}
+
+impl Eq for SortableDirEntry { }
+
+impl PartialOrd for SortableDirEntry {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.path().partial_cmp(other.path())
+    }
+}
+
+impl Ord for SortableDirEntry {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.path().cmp(other.path())
+    }
+}

--- a/src/file.rs
+++ b/src/file.rs
@@ -2,7 +2,7 @@ use std::fmt;
 use std::fs::File;
 use std::path::Path;
 use std::io::{Read, Result};
-use dedup::SortableDirEntry;
+use entry::Entry;
 use hex::Hex;
 use sha1::Sha1;
 use walkdir;
@@ -37,13 +37,13 @@ impl Iterator for FileIter {
 }
 
 #[derive(Debug)]
-pub struct FileHash {
-    pub entry: SortableDirEntry,
+pub struct FileHash<E> {
+    pub entry: E,
     pub hash: Vec<u8>,
 }
 
-impl FileHash {
-    pub fn from_entry(entry: SortableDirEntry) -> Result<FileHash> {
+impl<E: Entry> FileHash<E> {
+    pub fn from_entry(entry: E) -> Result<FileHash<E>> {
         Ok(FileHash {
             hash: hash_file(&entry.path())?,
             entry: entry,
@@ -51,7 +51,7 @@ impl FileHash {
     }
 }
 
-impl fmt::Display for FileHash {
+impl<E: Entry> fmt::Display for FileHash<E> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{{{}: {}}}", self.entry.path().display(), self.hash.hex())
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,13 +7,14 @@ extern crate walkdir;
 
 mod command;
 mod dedup;
+mod entry;
 mod file;
 mod hex;
 
 use std::fs;
 use std::path::Path;
 use command::{Command, CommandOptions};
-use dedup::SortableDirEntry;
+use entry::SortableDirEntry;
 use file::FileIter;
 use hex::Hex;
 


### PR DESCRIPTION
Here we use an `Entry` trait instead of a raw struct for performing the work we need to do in de-duplicating and removing files.
